### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The sample app: [click me](https://github.com/chenupt/SpringIndicator/raw/master
 
 ![gif](https://raw.githubusercontent.com/chenupt/SpringIndicator/master/img/si_1.0.0.gif)
 
-#Usage
+# Usage
 ---
 Add the dependency to your build.gradle.
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
